### PR TITLE
SV not matching due to Report date, CTM-804

### DIFF
--- a/pugh-lab/plugins/clinical_filter.py
+++ b/pugh-lab/plugins/clinical_filter.py
@@ -37,7 +37,7 @@ class PughLabClinicalFilter(ClinicalFilter):
         is_after_structured_sv_available = report_date and report_date >= datetime.datetime(2018, 12, 1, 0, 0, 0, 0)
 
         if has_structured_sv:
-            return is_after_structured_sv_available
+            return True
         elif has_unstructured_sv:
             return not is_after_structured_sv_available
         else:


### PR DESCRIPTION
All the clinical IDs are getting excluded based on report data when there is a SV criteria in query, so removed that checks as we no longer need it